### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DarkStarStrix/Nexa_Inference/security/code-scanning/6](https://github.com/DarkStarStrix/Nexa_Inference/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the provided workflow, the following permissions are needed:
- `contents: read` for accessing the repository contents.
- `pull-requests: write` for any potential pull request interactions (though none are explicitly shown in the current workflow).

The `permissions` block will be added at the root level, applying to all jobs in the workflow. If any job requires additional permissions in the future, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
